### PR TITLE
Add handling of resources in metricdata.Metric 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module contrib.go.opencensus.io/exporter/prometheus
 require (
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
+	github.com/google/go-cmp v0.3.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/procfs v0.0.6 // indirect
 	github.com/prometheus/statsd_exporter v0.15.0
@@ -11,3 +12,5 @@ require (
 )
 
 go 1.13
+
+replace go.opencensus.io => /usr/local/google/home/jjzeng/gohack/go.opencensus.io

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,8 @@ require (
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/procfs v0.0.6 // indirect
 	github.com/prometheus/statsd_exporter v0.15.0
-	go.opencensus.io v0.22.2
+	go.opencensus.io v0.22.4-0.20200608061201-1901b56b9515
 	golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056 // indirect
 )
 
 go 1.13
-
-replace go.opencensus.io => /usr/local/google/home/jjzeng/gohack/go.opencensus.io

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 go.opencensus.io v0.22.2 h1:75k/FF0Q2YM8QYo07VPddOLBslDt1MZOdEslOHvmzAs=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opencensus.io v0.22.4-0.20200608061201-1901b56b9515 h1:YS3N5IEX0gd5pYMAT6Am+LQPPuQTNRv11JaZY0+BV0Y=
+go.opencensus.io v0.22.4-0.20200608061201-1901b56b9515/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/prometheus.go
+++ b/prometheus.go
@@ -160,7 +160,7 @@ func (c *collector) toDesc(metric *metricdata.Metric) *prometheus.Desc {
 		for k, v := range c.opts.ConstLabels {
 			labels[k] = v
 		}
-		// Resource labels overwrite const labels
+		// Resource labels overwrite const labels.
 		for k, v := range metric.Resource.Labels {
 			labels[k] = v
 		}

--- a/prometheus.go
+++ b/prometheus.go
@@ -150,27 +150,27 @@ func newCollector(opts Options, registrar prometheus.Registerer) *collector {
 }
 
 func (c *collector) toDesc(metric *metricdata.Metric) *prometheus.Desc {
+	var labels prometheus.Labels
 	if metric.Resource == nil {
-		return prometheus.NewDesc(
-			metricName(c.opts.Namespace, metric),
-			metric.Descriptor.Description,
-			toPromLabels(metric.Descriptor.LabelKeys),
-			c.opts.ConstLabels)
-
+		labels = c.opts.ConstLabels
+	} else if c.opts.ConstLabels == nil {
+		labels = metric.Resource.Labels
+	} else {
+		labels = prometheus.Labels{}
+		for k, v := range c.opts.ConstLabels {
+			labels[k] = v
+		}
+		// Resource labels overwrite const labels
+		for k, v := range metric.Resource.Labels {
+			labels[k] = v
+		}
 	}
 
-	resourceLabels := c.opts.ConstLabels
-	if resourceLabels == nil {
-		resourceLabels = prometheus.Labels{}
-	}
-	for k, v := range metric.Resource.Labels {
-		resourceLabels[k] = v
-	}
 	return prometheus.NewDesc(
 		metricName(c.opts.Namespace, metric),
 		metric.Descriptor.Description,
 		toPromLabels(metric.Descriptor.LabelKeys),
-		resourceLabels)
+		labels)
 
 }
 

--- a/prometheus.go
+++ b/prometheus.go
@@ -150,11 +150,28 @@ func newCollector(opts Options, registrar prometheus.Registerer) *collector {
 }
 
 func (c *collector) toDesc(metric *metricdata.Metric) *prometheus.Desc {
+	if metric.Resource == nil {
+		return prometheus.NewDesc(
+			metricName(c.opts.Namespace, metric),
+			metric.Descriptor.Description,
+			toPromLabels(metric.Descriptor.LabelKeys),
+			c.opts.ConstLabels)
+
+	}
+
+	resourceLabels := c.opts.ConstLabels
+	if resourceLabels == nil {
+		resourceLabels = prometheus.Labels{}
+	}
+	for k, v := range metric.Resource.Labels {
+		resourceLabels[k] = v
+	}
 	return prometheus.NewDesc(
 		metricName(c.opts.Namespace, metric),
 		metric.Descriptor.Description,
 		toPromLabels(metric.Descriptor.LabelKeys),
-		c.opts.ConstLabels)
+		resourceLabels)
+
 }
 
 type metricExporter struct {

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -364,6 +364,20 @@ tests_baz{method="issue961",service="bigtable"} 1
 # TYPE tests_foo counter
 tests_foo{method="issue961",service="bigtable"} 1
 `,
+	}, {
+		name:        "const labels and resource with overlap and non-overlap",
+		constLabels: prometheus.Labels{"service": "spanner", "account": "test"},
+		resource:    &resource.Resource{Type: "test resource", Labels: map[string]string{"service": "bigtable", "region": "us-east"}},
+		want: `# HELP tests_bar bar
+# TYPE tests_bar counter
+tests_bar{account="test",method="issue961",region="us-east",service="bigtable"} 1
+# HELP tests_baz baz
+# TYPE tests_baz counter
+tests_baz{account="test",method="issue961",region="us-east",service="bigtable"} 1
+# HELP tests_foo foo
+# TYPE tests_foo counter
+tests_foo{account="test",method="issue961",region="us-east",service="bigtable"} 1
+`,
 	}}
 	measureLabel, _ := tag.NewKey("method")
 


### PR DESCRIPTION
This follows https://github.com/census-instrumentation/opencensus-go/pull/1212, which added resources to metricdata.Metric when specified.

This fix reads the resource labels, and treat them as const labels.